### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,20 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.0.0-M3</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>${junit.platform.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-engine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opentest4j</groupId>
+                    <artifactId>opentest4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
@MovingToWeb Hi, I am a user of project **_com.techprimers.testing:jenkins-example:1.0-SNAPSHOT_**. I found that its pom file introduced **_10_** dependencies. However, among them, **_7_** libraries (**_70%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.techprimers.testing:jenkins-example:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.opentest4j:opentest4j:jar:1.0.0-M1:compile
org.junit.platform:junit-platform-launcher:jar:1.0.0-M3:compile
org.junit.platform:junit-platform-engine:jar:1.0.0-M3:compile
org.junit.platform:junit-platform-commons:jar:1.0.0-M3:compile
org.hamcrest:hamcrest-core:jar:1.3:compile
org.junit.platform:junit-platform-runner:jar:1.0.0-M3:compile
junit:junit:jar:4.12:compile
</code></pre>